### PR TITLE
Revert "Cache the `.tox` directory on GitHub Actions"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Cache the .tox dir
-        uses: actions/cache@v3
-        with:
-          path: .tox
-          key: format-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            format-${{ runner.os }}-tox-
       - run: python -m pip install tox
-      - if: github.event.schedule
-        run: rm -rf .tox/checkformatting
       - run: tox -e checkformatting
   Lint:
     runs-on: ubuntu-latest
@@ -32,16 +23,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Cache the .tox dir
-        uses: actions/cache@v3
-        with:
-          path: .tox
-          key: lint-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            lint-${{ runner.os }}-tox-
       - run: python -m pip install tox
-      - if: github.event.schedule
-        run: rm -rf .tox/lint
       - run: tox -e lint
   Tests:
     runs-on: ubuntu-latest
@@ -55,16 +37,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache the .tox dir
-        uses: actions/cache@v3
-        with:
-          path: .tox
-          key: tests-${{ runner.os }}-${{ matrix.python-version }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            tests-${{ runner.os }}-${{ matrix.python-version }}-tox-
       - run: python -m pip install tox
-      - if: github.event.schedule
-        run: rm -rf .tox/tests
       - run: tox -e tests
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
@@ -80,20 +53,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Cache the .tox dir
-        uses: actions/cache@v3
-        with:
-          path: .tox
-          key: coverage-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            coverage-${{ runner.os }}-tox-
       - name: Download coverage files
         uses: actions/download-artifact@v3
         with:
           name: coverage
       - run: python -m pip install tox
-      - if: github.event.schedule
-        run: rm -rf .tox/coverage
       - run: tox -e coverage
   Functests:
     runs-on: ubuntu-latest
@@ -107,14 +71,5 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache the .tox dir
-        uses: actions/cache@v3
-        with:
-          path: .tox
-          key: functests-${{ runner.os }}-${{ matrix.python-version }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('setup.cfg') }}
-          restore-keys: |
-            functests-${{ runner.os }}-${{ matrix.python-version }}-tox-
       - run: python -m pip install tox
-      - if: github.event.schedule
-        run: rm -rf .tox/functests
       - run: tox -e functests


### PR DESCRIPTION
Reverts hypothesis/tox-envfile#2. This looks like it's going to work but the changes will have to be made properly in https://github.com/hypothesis/cookiecutters. Also, I'm going to use https://github.com/hypothesis/cookiecutter-pypackage-test for testing things from now on.