### PR TITLE
Fix crash when no `-e`

### DIFF
--- a/src/tox_envfile/main.py
+++ b/src/tox_envfile/main.py
@@ -10,6 +10,6 @@ hookimpl = pluggy.HookimplMarker("tox")
 def tox_configure(config):
     envvars = dotenv.dotenv_values(os.path.join(config.toxinidir, ".devdata.env"))
 
-    for env in config.option.env:
+    for envconfig in config.envconfigs.values():
         for name, value in envvars.items():
-            config.envconfigs[env].setenv[name] = value
+            envconfig.setenv[name] = value


### PR DESCRIPTION
`tox-envfile` has begun crashing when `tox` is run without any `-e` argument:

```terminal
Traceback (most recent call last):
  ...
  File ".../.tox/.tox/lib/python3.8/site-packages/tox_envfile/main.py", line 13, in tox_configure
    for env in config.option.env:
TypeError: 'NoneType' object is not iterable
```

I have no idea what changed in `tox-envfile` to cause this to start happening, but this commit attempts to fix the issue.

## Testing

Run these commands **in your Via HTML directory**:

1. Clone this branch of `tox-envfile` to a temporary directory:

   ```bash
   git clone -b fix-crash https://github.com/hypothesis/tox-envfile.git /tmp/tox-envfile
   ```

2. Run a command to generate Via HTML's `.tox/.tox` venv (if it doesn't already exist). For example:

   ```bash
   make checkformatting
   ```

3. Uninstall the production copy of `tox-envfile` from Via HTML's `.tox/.tox`:

   ```bash
   .tox/.tox/bin/pip uninstall tox-envfile
   ```

4. Install the development copy of `tox-envfile` into Via HTML's `.tox/.tox`:

   ```bash
   .tox/.tox/bin/pip install -e /tmp/tox-envfile
   ```

5. Your Via HTML commands should now hopefully be working again:

   ```bash
   make test
   ```

## Releasing this fix

If this fix works we'll have to release a new version of `tox-envfile` to PyPI (which you do by just creating a new GitHub release, see `HACKING.md`) and then either everyone who is seeing the bug will have to delete their `.tox` directories or we'll have to change `tox-envfile` to `tox-envfile>=0.0.4` in all our `tox.ini` files.